### PR TITLE
Fixed global variables for GCC 10.2

### DIFF
--- a/src/pmgc/mgsubd.c
+++ b/src/pmgc/mgsubd.c
@@ -54,6 +54,10 @@
 
 #include "mgsubd.h"
 
+double bf;
+double oh;
+double cputime;
+
 VPUBLIC void Vbuildops(
         int *nx, int *ny, int *nz,
         int *nlev, int *ipkey, int *iinfo,

--- a/src/pmgc/mgsubd.h
+++ b/src/pmgc/mgsubd.h
@@ -255,7 +255,7 @@ VEXTERNC int Vmaxlev(
 
 
 /// @todo  Get rid of these globals in refactor
-double bf, oh, cputme;
+extern double bf, oh, cputme;
 
 /** @brief   This routine prints out some info and such from inside multigrid.
  *  @author  Tucker Beck [C Translation], Michael Holst [Original]

--- a/src/pmgc/mypdec.c
+++ b/src/pmgc/mypdec.c
@@ -54,6 +54,18 @@
 
 #include "mypdec.h"
 
+double v1;
+double v2;
+double v3;
+double conc1;
+double conc2;
+double conc3;
+double vol;
+double relSize;
+int nion;
+double charge[MAXIONS];
+double sconc[MAXIONS];
+
 VPUBLIC void Vmypdefinitlpbe(int *tnion, double *tcharge, double *tsconc) {
 
     int i;

--- a/src/pmgc/mypdec.h
+++ b/src/pmgc/mypdec.h
@@ -67,10 +67,10 @@
 #define SINH_MAX  85.0
 
 /// @todo  Remove dependencies on global variables
-double v1, v2, v3, conc1, conc2, conc3, vol, relSize;
-int nion;
-double charge[MAXIONS];
-double sconc[MAXIONS];
+extern double v1, v2, v3, conc1, conc2, conc3, vol, relSize;
+extern int nion;
+extern double charge[MAXIONS];
+extern double sconc[MAXIONS];
 
 #define Na 6.022045000e-04
 


### PR DESCRIPTION
This should help close issue #55 linking errors with newer compilers. There is still a problem with BEM but it is a bit to large to do in one attempt.