### PR TITLE
WIP: Replace swig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,5 +62,5 @@ jobs:
           echo "==================================== BUILD =============================================== "
           ./.build.sh
         env:
-          # https://codecov.io/gh/Electrostatics/apbs-pdb2pqr
+          # https://codecov.io/gh/Electrostatics/apbs
           CODECOV_TOKEN: "e3a1e24c-5598-4f47-9353-7fa0ac57f98e"

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "externals/pb_solvers"]
 	path = externals/pb_solvers
 	url = https://github.com/Electrostatics/pb_solvers
+[submodule "externals/pybind11"]
+    path = externals/pybind11
+	url = https://github.com/pybind/pybind11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ OPTION(BUILD_SHARED_LIBS "Build shared libraries." OFF)
 message(STATUS "Setting project paths")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -fpermissive -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -fpermissive -fPIC")
 if(WIN32)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:100000000")
 endif()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pybind11>=2.5
 sphinx>=3.1
 sphinx_rtd_theme
 sphinx_sitemap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dev-tools>=2020.9.4
 pybind11>=2.5
 sphinx>=3.1
 sphinx_rtd_theme

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,5 +5,6 @@ add_subdirectory(manip)
 
 if(ENABLE_PYTHON)
     add_subdirectory(python)
+    add_subdirectory(python-pybind)
 endif(ENABLE_PYTHON)
 

--- a/tools/python-pybind/CMakeLists.txt
+++ b/tools/python-pybind/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+find_package(pybind11 REQUIRED)
+add_library(apbs_pybind
+  MODULE
+  module.cpp
+  bind_nosh.cpp)
+
+set_target_properties(apbs_pybind
+  PROPERTIES
+  PREFIX "${PYTHON_MODULE_PREFIX}"
+  SUFFIX "${PYTHON_MODULE_EXTENSION}"
+  OUTPUT_NAME "apbs"
+  )
+
+message(STATUS "LIBS ${APBS_LIBS}")
+message(STATUS "INTERNAL_LIBS ${APBS_INTERNAL_LIBS}")
+target_link_libraries(
+  apbs_pybind
+  PRIVATE
+  pybind11::module
+  ${APBS_LIBS}
+  ${APBS_INTERNAL_LIBS}
+  )
+
+install(TARGETS apbs_pybind LIBRARY DESTINATION ${PROJECT_BINARY_DIR}/lib)

--- a/tools/python-pybind/CMakeLists.txt
+++ b/tools/python-pybind/CMakeLists.txt
@@ -3,7 +3,10 @@ find_package(pybind11 REQUIRED)
 add_library(apbs_pybind
   MODULE
   module.cpp
-  bind_nosh.cpp)
+  bind_nosh.cpp
+  bind_vatom.cpp
+  bind_valist.cpp
+  )
 
 set_target_properties(apbs_pybind
   PROPERTIES

--- a/tools/python-pybind/bind_constants.hpp
+++ b/tools/python-pybind/bind_constants.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+/**
+ * @file tools/python-pybind/bind_constants.hpp
+ * @author Asher Mancinelli <asher.mancinelli@pnnl.gov>
+ * @brief Contains bindings for exported constants.
+ *
+ * @note The constants exported here were simply the same ones exported by the
+ * original SWIG python interface.
+ *
+ * @see tools/python/apbslib.c
+ */
+
+inline void bind_constants(py::module& m)
+{
+  m.attr("NPT_ENERGY") 		    = py::int_(static_cast<int>(NPT_ENERGY));
+  m.attr("NPT_FORCE") 		    = py::int_(static_cast<int>(NPT_FORCE));
+  m.attr("NPT_ELECENERGY") 		= py::int_(static_cast<int>(NPT_ELECENERGY));
+  m.attr("NPT_ELECFORCE") 		= py::int_(static_cast<int>(NPT_ELECFORCE));
+  m.attr("NPT_APOLENERGY") 		= py::int_(static_cast<int>(NPT_APOLENERGY));
+  m.attr("NPT_APOLFORCE") 		= py::int_(static_cast<int>(NPT_APOLFORCE));
+}

--- a/tools/python-pybind/bind_nosh.cpp
+++ b/tools/python-pybind/bind_nosh.cpp
@@ -1,0 +1,19 @@
+#include "bind_nosh.hpp"
+
+int parseInputFromString(NOsh *nosh, std::string str)
+{
+  int ret, bufsize;
+  Vio *sock;
+
+  startVio();
+
+  VASSERT( bufsize <= VMAX_BUFSIZE );
+  sock = Vio_ctor("BUFF","ASC",VNULL,"0","r");
+
+  Vio_bufTake(sock, str.c_str(), str.size());
+
+  ret = NOsh_parseInput(nosh, sock); 
+  sock->VIObuffer = VNULL;
+  Vio_dtor(&sock);
+  return ret;
+}

--- a/tools/python-pybind/bind_nosh.cpp
+++ b/tools/python-pybind/bind_nosh.cpp
@@ -10,7 +10,7 @@ int parseInputFromString(NOsh *nosh, std::string str)
   VASSERT( bufsize <= VMAX_BUFSIZE );
   sock = Vio_ctor("BUFF","ASC",VNULL,"0","r");
 
-  Vio_bufTake(sock, str.c_str(), str.size());
+  Vio_bufTake(sock, const_cast<char*>(str.c_str()), str.size());
 
   ret = NOsh_parseInput(nosh, sock); 
   sock->VIObuffer = VNULL;
@@ -52,7 +52,7 @@ void bind_nosh(py::module& m)
           VASSERT( bufsize <= VMAX_BUFSIZE );
           sock = Vio_ctor("BUFF","ASC",VNULL,"0","r");
 
-          Vio_bufTake(sock, str.c_str(), str.size());
+          Vio_bufTake(sock, const_cast<char*>(str.c_str()), str.size());
 
           ret = NOsh_parseInput(self, sock); 
           sock->VIObuffer = VNULL;

--- a/tools/python-pybind/bind_nosh.cpp
+++ b/tools/python-pybind/bind_nosh.cpp
@@ -17,3 +17,51 @@ int parseInputFromString(NOsh *nosh, std::string str)
   Vio_dtor(&sock);
   return ret;
 }
+
+void bind_nosh(py::module& m)
+{
+  m.def("getPotentials", &getPotentials<double>);
+
+  py::class_<NOsh_calc>(m, "NOsh_calc")
+    .def("__init__",
+        [] (NOsh_calc* self, NOsh_CalcType calcType)
+        {
+          self = NOsh_calc_ctor(calcType);
+        })
+    .def("NOsh_calc_mgparm_set",
+        [] (NOsh_calc* nosh, MGparm& mgparm)
+        {
+          nosh->mgparm = &mgparm;
+        })
+    .def("__del__",
+        [] (NOsh_calc* self)
+        {
+          NOsh_calc_dtor(&self);
+        });
+
+  py::class_<NOsh>(m, "NOsh")
+    .def(py::init<>())
+    .def("parseInputFromString",
+        [] (NOsh* self, std::string str) -> int
+        {
+          int ret, bufsize;
+          Vio *sock;
+
+          startVio();
+
+          VASSERT( bufsize <= VMAX_BUFSIZE );
+          sock = Vio_ctor("BUFF","ASC",VNULL,"0","r");
+
+          Vio_bufTake(sock, str.c_str(), str.size());
+
+          ret = NOsh_parseInput(self, sock); 
+          sock->VIObuffer = VNULL;
+          Vio_dtor(&sock);
+          return ret;
+        })
+    .def("__del__",
+        [] (NOsh* self)
+        {
+          NOsh_dtor(&self);
+        });
+}

--- a/tools/python-pybind/bind_nosh.hpp
+++ b/tools/python-pybind/bind_nosh.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <string>

--- a/tools/python-pybind/bind_nosh.hpp
+++ b/tools/python-pybind/bind_nosh.hpp
@@ -4,6 +4,12 @@
 #include <string>
 #include <vector>
 
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 extern "C"
 {
 #include "apbscfg.h" 
@@ -19,12 +25,11 @@ extern "C"
  * @brief Contains bindings for nosh-related functions.
  *
  * @note keep all implementations in the impl unless templated.
+ * @note contains bindings for nosh and all classes encapsulated by this struct
+ * within the source.
+ *
+ * @see src/generic/nosh.h:195
  */
-
-/**
- * @todo request help documenting
- */
-int parseInputFromString(NOsh *nosh, std::string str);
 
 /**
  * @todo request help documenting
@@ -65,3 +70,8 @@ std::vector<T> getPotentials(NOsh *nosh, PBEparm *pbeparm, Vpmg *pmg, Valist *al
     Vgrid_dtor(&grid);    
     return values;
 }
+
+/**
+ * @brief Perform binding to module
+ */
+void bind_nosh(py::module& m);

--- a/tools/python-pybind/bind_nosh.hpp
+++ b/tools/python-pybind/bind_nosh.hpp
@@ -1,0 +1,67 @@
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+extern "C"
+{
+#include "apbscfg.h" 
+#include "routines.h"
+#include "generic/nosh.h"
+#include "generic/valist.h"
+#include "generic/vatom.h"
+}
+
+/**
+ * @file tools/python-pybind/bind_nosh.hpp
+ * @author Asher Mancinelli <asher.mancinelli@pnnl.gov>
+ * @brief Contains bindings for nosh-related functions.
+ *
+ * @note keep all implementations in the impl unless templated.
+ */
+
+/**
+ * @todo request help documenting
+ */
+int parseInputFromString(NOsh *nosh, std::string str);
+
+/**
+ * @todo request help documenting
+ */
+template<typename T>
+std::vector<T> getPotentials(NOsh *nosh, PBEparm *pbeparm, Vpmg *pmg, Valist *alist)
+{
+    Vgrid *grid;
+    Vatom *atom; 
+    int i, rc, nx, ny, nz;
+    double hx, hy, hzed, xcent, ycent, zcent, xmin, ymin, zmin;
+    double value;
+    double *position;
+    std::vector<T> values;
+    
+    nx = pmg->pmgp->nx;
+    ny = pmg->pmgp->ny;
+    nz = pmg->pmgp->nz;
+    hx = pmg->pmgp->hx;
+    hy = pmg->pmgp->hy;
+    hzed = pmg->pmgp->hzed;
+    xcent = pmg->pmgp->xcent;
+    ycent = pmg->pmgp->ycent;
+    zcent = pmg->pmgp->zcent;
+    xmin = xcent - 0.5*(nx-1)*hx;
+    ymin = ycent - 0.5*(ny-1)*hy;
+    zmin = zcent - 0.5*(nz-1)*hzed;
+   
+    Vpmg_fillArray(pmg, pmg->rwork, VDT_POT, 0.0, pbeparm->pbetype, pbeparm);
+    grid = Vgrid_ctor(nx, ny, nz, hx, hy, hzed, xmin, ymin, zmin,
+                  pmg->rwork);
+    for (i=0;i<Valist_getNumberAtoms(alist);i++){
+        atom = Valist_getAtom(alist, i);
+        position = Vatom_getPosition(atom); 
+        Vgrid_value(grid, position, &value);
+        values[i] = value;
+    } 
+    Vgrid_dtor(&grid);    
+    return values;
+}

--- a/tools/python-pybind/bind_nosh.hpp
+++ b/tools/python-pybind/bind_nosh.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 namespace py = pybind11;
 
 #ifdef __GNUC__

--- a/tools/python-pybind/bind_valist.cpp
+++ b/tools/python-pybind/bind_valist.cpp
@@ -1,7 +1,66 @@
 #include "bind_valist.hpp"
 
-void bind_valist(py::module& m)
+void Valist_load(Valist *self,
+                 int size,
+                 std::vector<double> x,
+                 std::vector<double> y,
+                 std::vector<double> z,
+                 std::vector<double> chg,
+                 std::vector<double> rad)
+{
+
+  int i, j;
+  double pos[3];
+
+  Vatom *atom;
+
+  VASSERT(self != VNULL);
+
+  self->atoms = static_cast<Vatom*>(Vmem_malloc(self->vmem, size, sizeof(Vatom)));
+  self->number = size;
+  for (i = 0; i < size; i++) {
+    pos[0] = x[i];
+    pos[1] = y[i];
+    pos[2] = z[i];
+    Vatom_setCharge(&(self->atoms[i]), chg[i]);
+    Vatom_setRadius(&(self->atoms[i]), rad[i]);
+    Vatom_setPosition(&(self->atoms[i]), pos);
+    Vatom_setAtomID(&(self->atoms[i]), i);
+  }
+
+  self->center[0] = 0.0;
+  self->center[1] = 0.0;
+  self->center[2] = 0.0;
+  self->maxrad = 0.0;
+  self->charge = 0.0;
+
+  /* Reset stat variables */
+  atom = &(self->atoms[0]);
+  for (i = 0; i < 3; i++) {
+    self->maxcrd[i] = self->mincrd[i] = atom->position[i];
+  }
+  self->maxrad = atom->radius;
+
+  for (i = 0; i < self->number; i++) {
+    atom = &(self->atoms[i]);
+    for (j = 0; j < 3; j++) {
+      if (atom->position[j] < self->mincrd[j])
+        self->mincrd[j] = atom->position[j];
+      if (atom->position[j] > self->maxcrd[j])
+        self->maxcrd[j] = atom->position[j];
+    }
+    if (atom->radius > self->maxrad) self->maxrad = atom->radius;
+    self->charge = self->charge + atom->charge;
+  }
+
+  self->center[0] = 0.5 * (self->maxcrd[0] + self->mincrd[0]);
+  self->center[1] = 0.5 * (self->maxcrd[1] + self->mincrd[1]);
+  self->center[2] = 0.5 * (self->maxcrd[2] + self->mincrd[2]);
+}
+
+void bind_valist(py::module &m)
 {
   py::class_<Valist>(m, "Valist")
-    .def(py::init<>());
+    .def(py::init<>())
+    .def("load", &Valist_load);
 }

--- a/tools/python-pybind/bind_valist.cpp
+++ b/tools/python-pybind/bind_valist.cpp
@@ -1,0 +1,7 @@
+#include "bind_valist.hpp"
+
+void bind_valist(py::module& m)
+{
+  py::class_<Valist>(m, "Valist")
+    .def(py::init<>());
+}

--- a/tools/python-pybind/bind_valist.hpp
+++ b/tools/python-pybind/bind_valist.hpp
@@ -3,6 +3,10 @@
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 extern "C"
 {
 #include "generic/valist.h"
@@ -21,6 +25,6 @@ extern "C"
  */
 
 /**
- * @brief Perform binding of _Vatom_ to module
+ * @brief Perform binding to module
  */
-void bind_vatom(py::module& m);
+void bind_valist(py::module& m);

--- a/tools/python-pybind/bind_valist.hpp
+++ b/tools/python-pybind/bind_valist.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include <vector>
 
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -23,6 +25,17 @@ extern "C"
  *
  * @see src/generic/valist.h:195
  */
+
+/**
+ * @todo request documentation for this
+ */
+void Valist_load(Valist *self,
+                 int size,
+                 std::vector<double> x,
+                 std::vector<double> y,
+                 std::vector<double> z,
+                 std::vector<double> chg,
+                 std::vector<double> rad);
 
 /**
  * @brief Perform binding to module

--- a/tools/python-pybind/bind_vatom.cpp
+++ b/tools/python-pybind/bind_vatom.cpp
@@ -1,0 +1,5 @@
+#include "bind_vatom.hpp"
+
+void bind_vatom(py::module& m)
+{
+}

--- a/tools/python-pybind/module.cpp
+++ b/tools/python-pybind/module.cpp
@@ -1,6 +1,12 @@
 #include <pybind11/pybind11.h>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 #include "bind_nosh.hpp"
+#include "bind_vatom.hpp"
+#include "bind_valist.hpp"
+#include "bind_constants.hpp"
 
 /**
  * @file tools/python-pybind/module.cpp
@@ -17,7 +23,11 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(apbs, m) {
   m.doc() = R"pbdoc(
+    
     )pbdoc";
 
   bind_nosh(m);
+  bind_vatom(m);
+  bind_valist(m);
+  bind_constants(m);
 }

--- a/tools/python-pybind/module.cpp
+++ b/tools/python-pybind/module.cpp
@@ -1,0 +1,24 @@
+#include <pybind11/pybind11.h>
+
+#include "bind_nosh.hpp"
+
+/**
+ * @file tools/python-pybind/module.cpp
+ * @author Asher Mancinelli <asher.mancinelli@pnnl.gov>
+ *
+ * @brief Glue code that binds each function/class to python
+ *
+ * @note Keep all binding functions in their own header/impl pair. No raw
+ * functions should live in this file; this is for *binding only*.
+ */
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(apbs, m) {
+  m.doc() = R"pbdoc(
+    )pbdoc";
+
+  /// @see bind_nosh.hpp
+  m.def("parseInputFromString", &parseInputFromString);
+  m.def("getPotentials", &getPotentials<double>);
+}

--- a/tools/python-pybind/module.cpp
+++ b/tools/python-pybind/module.cpp
@@ -6,10 +6,11 @@
  * @file tools/python-pybind/module.cpp
  * @author Asher Mancinelli <asher.mancinelli@pnnl.gov>
  *
- * @brief Glue code that binds each function/class to python
+ * @brief Creates python module and passes to each binding function.
  *
  * @note Keep all binding functions in their own header/impl pair. No raw
- * functions should live in this file; this is for *binding only*.
+ * functions or binding should live in this file; this is for creating the
+ * module and passing to binding functions only.
  */
 
 namespace py = pybind11;
@@ -18,7 +19,5 @@ PYBIND11_MODULE(apbs, m) {
   m.doc() = R"pbdoc(
     )pbdoc";
 
-  /// @see bind_nosh.hpp
-  m.def("parseInputFromString", &parseInputFromString);
-  m.def("getPotentials", &getPotentials<double>);
+  bind_nosh(m);
 }


### PR DESCRIPTION
@intendo @sobolevnrm Please leave review comments on the API I've exposed here. Let me know if this is how you'd like to interact with the C code from the python side - since we're already replacing the SWIG interface, this would be a good time to air your wishlist. Currently working example:

```bash
$ # make sure you have both swig and pybind11 installed for now while we gradually replace swig
$ cmake .. -DENABLE_PYTHON=ON -DENABLE_TOOLS=ON
$ make -j
$ cd lib
$ python3
Python 3.8.5 (default, Jul 21 2020, 10:48:26)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from apbs import NOsh
>>> nosh = NOsh()
>>> nosh.parseInputFromString(...)
```
From here, we can easily expose any of the C code as a clean and intuitive OO interface, but if either of you would like something different, please comment here.

- [x] @intendo's comments
- [x] @sobolevnrm's comments
- [ ] API review
- [ ] highest-priority kernels exposed through python
    - (please comment which kernels should go here)