### PR TITLE
Fixing formatting specifier for sscanf

### DIFF
--- a/src/mg/vgrid.c
+++ b/src/mg/vgrid.c
@@ -748,7 +748,7 @@ VPUBLIC int Vgrid_readDX(Vgrid *thee,
     VJMPERR1(!strcmp(tok, "items"));
     /* Get # */
     VJMPERR2(1 == Vio_scanf(sock, "%s", tok));
-    VJMPERR1(1 == sscanf(tok, "%lu", &itmp));
+    VJMPERR1(1 == sscanf(tok, "%zu", &itmp));
     u = (size_t)thee->nx * thee->ny * thee->nz;
     VJMPERR1(u == itmp);
     /* Get "data" */


### PR DESCRIPTION
Darren and Nathan, how has this issue not come up before? Do we need to go through and change all of the formatting specifiers in the parsers? This fixed issue #95, but I can imagine a million other corner cases where this could come up again.