### PR TITLE
Added --config option to dump compile-time options

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -82,6 +82,14 @@ int main(
          char **argv  /**< Argument strings */
          )
 {
+    // Dump compile-time options
+    for (int i=0; i<argc; i++) {
+        if (strcmp(argv[i],"--config")==0) {
+            dump_options();
+            return 0;
+        }
+    }
+
     // PCE: Adding below variables temporarily
     clock_t ts, te;
     // End PCE
@@ -238,6 +246,7 @@ int main(
     for type are either \"xml\" or \"flat\".\n\
 --help                   Display this help information.\n\
 --version                Display the current APBS version.\n\
+--config                 Display configuration options APBS was built with.\n\
 ----------------------------------------------------------------------\n\n"};
 
     /* ************** CHECK PARALLEL STATUS *************** */

--- a/src/routines.c
+++ b/src/routines.c
@@ -5563,3 +5563,142 @@ VPUBLIC int solvePBSAM( Valist* molecules[NOSH_MAXMOL],
 }
 
 #endif
+
+/**
+ * Dump compile-time options
+ */
+VPUBLIC void dump_options()
+{
+    puts("Apbs configuration:");
+
+    printf("PACKAGE_STRING:%s",PACKAGE_STRING);
+
+    printf("APBS_FAST:");
+#ifdef APBS_FAST
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("DEBUG:");
+#ifdef DEBUG
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("VERBOSE_DEBUG:");
+#ifdef VERBOSE_DEBUG
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("VAPBSQUIET:");
+#ifdef VAPBSQUIET
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_TIME_FUNC:");
+#ifdef HAVE_TIME_FUNC
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_RAND_FUNC:");
+#ifdef HAVE_RAND_FUNC
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_SRAND_FUNC:");
+#ifdef HAVE_SRAND_FUNC
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_LIBREADLINE:");
+#ifdef HAVE_LIBREADLINE
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("APBS_NOINLINE:");
+#ifdef APBS_NOINLINE
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_EMBED:");
+#ifdef HAVE_EMBED
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_ZLIB:");
+#ifdef HAVE_ZLIB
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("WITH_TINKER:");
+#ifdef WITH_TINKER
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("FETK_ENABLED:");
+#ifdef FETK_ENABLED
+    printf("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_PUNC_H:");
+#ifdef HAVE_PUNC_H
+    puts("1");
+#else
+    printf("0");
+#endif
+
+    printf("HAVE_MCX_H:");
+#ifdef HAVE_MCX_H
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_MC_H:");
+#ifdef HAVE_MC_H
+    printf("1");
+#else
+    puts("0");
+#endif
+
+    printf("HAVE_BIOM_H:");
+#ifdef HAVE_BIOM_H
+    puts("1");
+#else
+    printf("0");
+#endif
+
+    printf("HAVE_MPI_H:");
+#ifdef HAVE_MPI_H
+    puts("1");
+#else
+    puts("0");
+#endif
+
+    printf("FLOAT_EPSILON:%f\n",FLOAT_EPSILON);
+    printf("DOUBLE_EPSILON:%f\n",DOUBLE_EPSILON);
+}

--- a/src/routines.h
+++ b/src/routines.h
@@ -868,3 +868,9 @@ VEXTERNC int solvePBSAM(
                                 PBSAMparm *samparm
 );
 #endif
+
+/**
+ * @brief Dump compile-time options to I/O
+ * @ingroup Frontend
+ */
+VEXTERNC void dump_options();


### PR DESCRIPTION
As per offline conversation with @intendo, this is needed to convert testing system to pytest. Very surface-level PR which adds a single option to APBS driver. CC @sobolevnrm 