### PR TITLE
Issue 119

### DIFF
--- a/apbs/chemistry/atom_list.py
+++ b/apbs/chemistry/atom_list.py
@@ -20,14 +20,23 @@ class AtomList:
 
         :param List atoms: A list of Atoms
         """
-        self._atoms: Tuple[Atom] = atoms if atoms is not None else []
+        self._atoms: List[Atom] = atoms if atoms is not None else []
         self.charge: float = None
         self.maxrad: float = None
 
         self._center = Coordinate()
         self._min_coord = Coordinate()
         self._max_coord = Coordinate()
-        self._dp = dict()
+        self._dp = {}
+
+    def __getattr__(self, method):
+        return getattr(self._atoms, method)
+
+    def __len__(self):
+        return len(self._atoms)
+
+    def __getitem__(self, item):
+        return self._atoms[item]
 
     def center(self) -> Coordinate:
         """Molecule center

--- a/apbs/pqr/reader.py
+++ b/apbs/pqr/reader.py
@@ -1,4 +1,18 @@
-from pyparsing import Group, Literal, Word, ZeroOrMore, alphas, alphanums, nums
+from string import whitespace
+from pyparsing import (
+    Group,
+    LineEnd,
+    LineStart,
+    Literal,
+    Regex,
+    Word,
+    ZeroOrMore,
+    alphas,
+    alphanums,
+    nums,
+    printables,
+)
+import re
 from apbs.chemistry import Atom, AtomList
 
 
@@ -7,14 +21,24 @@ class PQRReader:
 
     def __init__(self):
         """Define the grammar for an ATOM/HETATM in PQR format."""
-        identifier = Word(alphas, alphanums + "_")
+        identifier = Word(alphas, alphanums + r"_")
+        alphanumidentifier = Word(alphanums + r"_" + r"'" + r"*")
         integer_val = Word(nums + "-")
         float_val = Word(nums + "-" + ".")
+        anything = Word(printables + " " + "\t")
         keyword_val = Literal("ATOM") | Literal("HETATM")
+        skip_val = Literal("TER") | Literal("END") | Literal("REMARK")
+        skip_value = Group(
+            LineStart()
+            + skip_val("field_name")
+            + anything("anything")
+            + LineEnd()
+        )
         atom_value = Group(
-            keyword_val("field_name")
+            LineStart()
+            + keyword_val("field_name")
             + integer_val("atom_number")
-            + identifier("atom_name")
+            + alphanumidentifier("atom_name")
             + identifier("residue_name")
             + ZeroOrMore(identifier("chain_id"))
             + integer_val("residue_number")
@@ -24,8 +48,10 @@ class PQRReader:
             + float_val("z")
             + float_val("charge")
             + float_val("radius")
+            + LineEnd()
         )
-        self.atom = atom_value + ZeroOrMore(atom_value)
+        # NOTE: Skips blank or lines with only whitespace (tabs, spaces, etc.)
+        self.atom = ZeroOrMore(atom_value | skip_value)
 
     def loads(self, pqr_string: str) -> AtomList:
         """
@@ -37,24 +63,26 @@ class PQRReader:
         """
         atoms = []
         idx: int = 1
-        for item, _start, _stop in self.atom.scanString(pqr_string):
-            for match in item:
-                atom = Atom(
-                    field_name=match.field_name,
-                    atom_number=int(match.atom_number),
-                    atom_name=match.atom_name,
-                    residue_name=match.residue_name,
-                    chain_id=match.chain_id,
-                    residue_number=int(match.residue_number),
-                    ins_code=match.ins_code,
-                    x=float(match.x),
-                    y=float(match.y),
-                    z=float(match.z),
-                    charge=float(match.charge),
-                    radius=float(match.radius),
-                    id=int(idx),
-                )
-                atoms.append(atom)
+        matches = self.atom.parseString(pqr_string, parseAll=True)
+        for match in matches:
+            if re.search("REMARK|TER|END", match.field_name) is not None:
+                continue
+            atom = Atom(
+                field_name=match.field_name,
+                atom_number=int(match.atom_number),
+                atom_name=match.atom_name,
+                residue_name=match.residue_name,
+                chain_id=match.chain_id,
+                residue_number=int(match.residue_number),
+                ins_code=match.ins_code,
+                x=float(match.x),
+                y=float(match.y),
+                z=float(match.z),
+                charge=float(match.charge),
+                radius=float(match.radius),
+                id=int(idx),
+            )
+            atoms.append(atom)
             idx += 1
         return AtomList(atoms)
 
@@ -67,7 +95,7 @@ class PQRReader:
         :rtype: AtomList
         """
         with open(filename, "r") as fp:
-            data = fp.read().replace("\n", "")
+            data = fp.read()
         return self.loads(data)
 
 

--- a/apbs/test/conftest.py
+++ b/apbs/test/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/apbs/test/test_pqr/test_pqrreader.py
+++ b/apbs/test/test_pqr/test_pqrreader.py
@@ -1,31 +1,65 @@
 import pathlib
+import pytest
+from pyparsing import ParseException
 from apbs.chemistry.atom_list import AtomList
 from apbs.pqr import PQRReader
 
 
+def search_dir(opt_path):
+    return (
+        pathlib.Path(__file__).parent.parent.parent.parent.absolute()
+        / "examples"
+        / opt_path
+    )
+
+
 class TestPQRReader:
-    def test_ctor(self):
+    def test_basic(self):
+        """This test values in the records in the sample data"""
         sut = PQRReader()
         sample = r"""
 ATOM   5226  HD1 TYR   337     -24.642  -2.718  30.187  0.115 1.358
-ATOM      7  CD   LYS D   1      44.946 37.289  9.712    -0.0608  1.9080
-REMARK This is just a comment hiding in the data
+                  
 HETATM     39 O3PB ADP     1     -16.362  -6.763  26.980 -0.900 1.700
+ATOM      7  CD   LYS D   1      44.946 37.289  9.712    -0.0608  1.9080
+REMARK This is just a   comment hid ing in the data
 ATOM     39 O3PB ADP     1  D   -16.362  -6.763  26.980 -0.900 1.700
+"""
+        atomlist: AtomList = sut.loads(sample)
+        assert len(atomlist) == 4
+        assert atomlist[1].field_name in "HETATM"
+        for idx in range(1):
+            assert abs(atomlist[idx].x - -24.642) < 0.001
+            assert int(atomlist[idx].x) == -24
+
+    @pytest.mark.xfail(
+        raises=ParseException,
+        reason="This should fail because of typo in data",
+    )
+    def test_bad(self):
+        """This test will fail because there is a typo in the sample data"""
+        sut = PQRReader()
+        sample = r"""
+ATOM   5226  HD1 TYR   337     -24.642  -2.718  30.187  0.115 1.358
 REMARK The next line is incorrect on purpose (e.g. ATAM instead of ATOM)
 ATAM     39 O3PB ADP     1  D   -16.362  -6.763  26.980 -0.900 1.700
 """
         atomlist: AtomList = sut.loads(sample)
-        for idx in range(1):
-            assert abs(atomlist.atoms[idx].x - -24.642) < 0.001
-            assert int(atomlist.atoms[idx].x) == -24
-        print(atomlist.atoms)
 
     def test_load(self):
+        """Test to load all the data from an example file"""
         sut = PQRReader()
-        pqr_imput = (
-            pathlib.Path(__file__).parent.parent.parent.parent.absolute()
-            / "examples/actin-dimer/mol1.pqr"
-        )
+        pqr_imput = search_dir("actin-dimer/mol1.pqr")
         atomlist: AtomList = sut.load(pqr_imput)
-        assert len(atomlist.atoms) == 5861
+        assert len(atomlist) == 5877
+
+    @pytest.mark.slow
+    def test_load_all(self):
+        """Test to load all the data from all the example files"""
+        sut = PQRReader()
+        # NOTE: There are 77 files under the examples directory
+        matches = pathlib.Path(search_dir("")).glob("**/*.pqr")
+        for match in matches:
+            print(f"FILE: {match}")
+            atomlist: AtomList = sut.load(match)
+            assert len(atomlist) > 0


### PR DESCRIPTION
This should fix the problems with #119. 

We added more exhaustive testing including all the pqr files in the examples directory. 

The parser now handles:
- special characters in the atom name (e.g. `'`, `*`)
- blank lines
- REMARK, TER, and END lines

The parser now fails with a ParseError if there are lines that don't follow the grammar (before, it just ignored lines it did not understand)